### PR TITLE
PKGBUILD: Add missing dependency and cleanup

### DIFF
--- a/pkg/arch/PKGBUILD
+++ b/pkg/arch/PKGBUILD
@@ -2,16 +2,15 @@
 pkgname=solo2-cli
 pkgver=0.0.6
 _pkgver=0.0.6
-pkgrel=1
+pkgrel=2
 pkgdesc='Solo 2 CLI'
 arch=('x86_64')
 url="https://github.com/solokeys/solo2-cli"
 license=(Apache MIT)
 # we only need `libudev.so`, during build we also need `pkgconfig/udev/.pc`
-depends=(systemd-libs)
+depends=(systemd-libs pcsclite)
 # note we do not need Arch `hidapi` package here, it's a git submodule of Rust hidapi
 makedepends=(cargo git systemd)
-conflicts=(solo2-cli-git)
 source=(
 	"$pkgname-$pkgver.tar.gz::https://github.com/solokeys/solo2-cli/archive/refs/tags/v${_pkgver}.tar.gz"
 )
@@ -21,14 +20,12 @@ sha256sums=(
 
 build() {
   cd "${pkgname}-${_pkgver}"
-  cargo build --release --locked
+  cargo build --frozen --release --all-features
 }
 
 check() {
   cd "${pkgname}-${_pkgver}"
-  # make sure shared libs work
-  target/release/solo2 --version
-  cargo test --release
+  cargo test --frozen --all-features
 }
 
 package() {
@@ -37,9 +34,9 @@ package() {
   install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgnamefull/LICENSE-MIT"
 
   # completions
-  install -Dm644 target/release/_solo2 -t $pkgdir/usr/share/zsh/site-functions
-  install -Dm644 target/release/solo2.bash $pkgdir/usr/share/bash-completion/completions/solo2
+  install -Dm644 target/release/_solo2 -t "$pkgdir/usr/share/zsh/site-functions"
+  install -Dm644 target/release/solo2.bash "$pkgdir/usr/share/bash-completion/completions/solo2"
 
   # udev rule
-  install -Dm644 70-solo2.rules -t $pkgdir/usr/lib/udev/rules.d
+  install -Dm644 70-solo2.rules -t "$pkgdir/usr/lib/udev/rules.d"
 }


### PR DESCRIPTION
This adds the missing  pcsclite dependency to the build. Also a couple
of cleanups:

* The vcs package should reverse conflict. This is not the job of this package
* quoted $pkgdir as it might contain spaces
* Remove the `--version` check as any linking issues should be detected during build
* Add --frozen and ensure the building in inline with guidelines

https://wiki.archlinux.org/title/Rust_package_guidelines

Signed-off-by: Morten Linderud <morten@linderud.pw>