### PR TITLE
Use SemVer instead of CalVer, resolves #27

### DIFF
--- a/src/bin/solo2/main.rs
+++ b/src/bin/solo2/main.rs
@@ -111,7 +111,7 @@ fn try_main(args: clap::ArgMatches<'_>) -> anyhow::Result<()> {
             }
             if args.subcommand_matches("version").is_some() {
                 let version = app.version()?;
-                println!("{}", version.to_calver());
+                println!("{}", version.to_semver());
             }
         }
 
@@ -355,7 +355,7 @@ fn try_main(args: clap::ArgMatches<'_>) -> anyhow::Result<()> {
 
         println!(
             "Fetched firmware version {}",
-            &firmware.version().to_calver()
+            &firmware.version().to_semver()
         );
 
         if update_all {

--- a/src/device.rs
+++ b/src/device.rs
@@ -37,7 +37,7 @@ impl fmt::Display for Solo2 {
             f,
             "Solo 2 {:X} (firmware {})",
             &self.uuid.to_simple(),
-            &self.version().to_calver()
+            &self.version().to_semver()
         )
     }
 }
@@ -198,8 +198,8 @@ impl Device {
                 let device_version: Version = admin.version()?;
                 let new_version = firmware.version();
 
-                info!("current device version: {}", device_version.to_calver());
-                info!("new firmware version: {}", new_version.to_calver());
+                info!("current device version: {}", device_version.to_semver());
+                info!("new firmware version: {}", new_version.to_semver());
 
                 if !skip_major_prompt && new_version.major > device_version.major {
                     use dialoguer::{theme, Confirm};


### PR DESCRIPTION
Turns out there were only 4 uses of `to_calver`, all obviously just for end-user display. Decided to just quickly do it myself.
I don't think this even has any chance to break anything, unless the `to_semver` doesn't work properly.

Resolves #27 