### PR TITLE
Fix secret shortening in oath app

### DIFF
--- a/src/apps/oath.rs
+++ b/src/apps/oath.rs
@@ -98,7 +98,8 @@ impl Secret {
     /// Note: The secret is later used as an HMAC key.
     ///
     /// It is a property of HMAC that a key that is longer than the digest
-    /// output size is first shortened by applying the digest.
+    /// block size is first shortened by applying the digest. For SHA-1 and
+    /// SHA-2, the block size is 64 bytes (512 bits).
     ///
     /// Therefore, applying the shortening in this implementation has no effect
     /// on the calculated OTP, but it does make communication with the OATH
@@ -117,12 +118,13 @@ impl Secret {
         let mut shortened = match digest {
             Digest::Sha1 => {
                 use sha1::{Digest, Sha1};
-                if unshortened.len() > Sha1::output_size() {
+                let block_size = 64;
+                if unshortened.len() > block_size {
                     trace!(
                         "shortening {} as {} > {}",
                         hex::encode(&unshortened),
                         unshortened.len(),
-                        Sha1::output_size()
+                        block_size
                     );
                     let shortened = Sha1::digest(&unshortened).as_slice().to_vec();
                     trace!("...to {}", hex::encode(&shortened));
@@ -133,12 +135,13 @@ impl Secret {
             }
             Digest::Sha256 => {
                 use sha2::{Digest, Sha256};
-                if unshortened.len() > Sha256::output_size() {
+                let block_size = 64;
+                if unshortened.len() > block_size {
                     trace!(
                         "shortening {} as {} > {}",
                         hex::encode(&unshortened),
                         unshortened.len(),
-                        Sha256::output_size()
+                        block_size
                     );
                     let shortened = Sha256::digest(&unshortened).as_slice().to_vec();
                     trace!("...to {}", hex::encode(&shortened));


### PR DESCRIPTION
The oath app attempts to shorten secrets (by hashing them) if they exceed a specific length.

This change adjusts the calculation so that it uses the block size of the hash algorithm to decide when to shorten the secret.

Previously, the output size was used, instead of the block size. This meant that secrets that were added to the device that exceeded the output size, but not the block size, would end up getting hashed twice.

I ran into this issue when trying to add my Amazon account. I had to manually add padding to my base32 secret, which was a bit unexpected. Once I got past that, I found that the OATH-TOTP codes were not working. After enabling trace logging, I found that my secret wasn't getting sent to (or stored on) my device, but rather the hashed version of it, even though it didn't exceed the block size. After making this change, I was able to successfully register my Amazon account and get valid TOTP codes.