### PR TITLE
Fix listing for smartcards when multiple readers are present

### DIFF
--- a/src/device/pcsc.rs
+++ b/src/device/pcsc.rs
@@ -94,8 +94,8 @@ impl Session {
             .session
             .list_readers(&mut card_names_buffer)?
             .map(|name_cstr| name_cstr.to_string_lossy().to_string())
-            .map(|name| {
-                let device = self.connect(&name).unwrap();
+            .filter_map(|name| self.connect(&name).ok().map(|device| (name, device)))
+            .map(|(name, device)| {
                 Info {
                     name,
                     // kind: device.attribute(pcsc::Attribute::VendorIfdType),


### PR DESCRIPTION
Fixes #55 

With multiple smartcard readers connected (although some empty), the call to PCSC session connect would panic.
With this pr, invalid readers are ignored.