### PR TITLE
Add "dependency CCID is not satisfied" error message

### DIFF
--- a/src/transport/ctap.rs
+++ b/src/transport/ctap.rs
@@ -87,6 +87,7 @@ impl From<u8> for Code {
             0x3F => Error,
             0x3B => Keepalive,
             vendor_code @ 0x40..=0x7F => Vendor(VendorCode::new(vendor_code)),
+            0xA4 | 0xA1 => panic!("dependency CCID is not satisfied"),
             _ => panic!(),
         }
     }


### PR DESCRIPTION
Adding my two cents to the repository. :3

The error code isn't helpful at all, the error 0xA1 and 0xA4 means that the CCID capability is missing.

See #32 for more information