### PR TITLE
Migrate to sha1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,10 +1752,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
+name = "sha1"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1830,7 +1830,7 @@ dependencies = [
  "rand_core",
  "rcgen",
  "serde_json",
- "sha-1",
+ "sha1",
  "sha2",
  "time 0.3.17",
  "ureq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ lpc55 = "0.2"
 pcsc = "2.4"
 # reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0.64"
-sha-1 = "0.10"
+sha1 = "0.10"
 sha2 = "0.10"
 time = "0.3"
 x509-parser = { version = "0.14.0", features = ["verify"] }


### PR DESCRIPTION
As the sha-1 crate is deprecated, the sha1 crate should be used. Compiles fine and can communicate with a solo2 key.