### PR TITLE
Add missing quote to the udev rule proposal

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -374,7 +374,7 @@ impl Device {
                             println!("Either run `sudo solo2 update`, or install <https://github.com/solokeys/solo2-cli/blob/main/70-solo2.rules>");
                             println!("Specifically, you need this line:");
                             // SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b000", TAG+="uaccess"
-                            println!(r#"SUBSYSTEM=="hidraw", ATTRS{{idVendor}}=="1209", ATTRS{{idProduct}}=="b000", TAG+="uaccess"#);
+                            println!(r#"SUBSYSTEM=="hidraw", ATTRS{{idVendor}}=="1209", ATTRS{{idProduct}}=="b000", TAG+="uaccess""#);
                             println!();
                         }
                         e


### PR DESCRIPTION
A tiny PR to fix an incomplete message :)

```
✔ Continue? · yes
Continuing
Tap button on key to confirm, or replug to abort...

If you touched the key and the LED is off, you are likely missing udev rules for LPC 55 mode.
Either run `sudo solo2 update`, or install <https://github.com/solokeys/solo2-cli/blob/main/70-solo2.rules>
Specifically, you need this line:
SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="b000", TAG+="uaccess

Error: User prompt to confirm maintenance timed out (or udev rules for LPC 55 mode missing)!
```